### PR TITLE
Fix code scanning alert no. 3: Missing rate limiting

### DIFF
--- a/royalgames-server/index.js
+++ b/royalgames-server/index.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const cors = require('cors');  // Import CORS
 const path = require('path');
+const RateLimit = require('express-rate-limit');
 const app = express();
 
 require('dotenv').config();
@@ -28,6 +29,15 @@ app.use(cors({
   },
   credentials: true
 }));
+
+// Set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
+
+// Apply rate limiter to all requests
+app.use(limiter);
 
 // Serve static files from the public directory
 app.use(express.static(path.join(__dirname, 'public')));

--- a/royalgames-server/package.json
+++ b/royalgames-server/package.json
@@ -30,7 +30,8 @@
     "socket.io": "^4.8.0",
     "sqlite3": "^5.1.7",
     "uuid": "^10.0.0",
-    "winston": "^3.15.0",
+    "dotenv": "^16.0.3",
+    "express-rate-limit": "^7.4.1"
     "dotenv": "^16.0.3"
   }
 }

--- a/royalgames-server/package.json
+++ b/royalgames-server/package.json
@@ -30,8 +30,8 @@
     "socket.io": "^4.8.0",
     "sqlite3": "^5.1.7",
     "uuid": "^10.0.0",
+    "winston" "*",
     "dotenv": "^16.0.3",
     "express-rate-limit": "^7.4.1"
-    "dotenv": "^16.0.3"
   }
 }


### PR DESCRIPTION
Fixes [https://github.com/realbrodiwhite/royalgames/security/code-scanning/3](https://github.com/realbrodiwhite/royalgames/security/code-scanning/3)

To fix the problem, we will introduce rate limiting using the `express-rate-limit` package. This package allows us to limit the number of requests a client can make to the server within a specified time window. We will configure the rate limiter to allow a maximum of 100 requests per 15 minutes and apply it to all routes, including the one serving the static `index.html` file.

**Steps to implement the fix:**
1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `royalgames-server/index.js` file.
3. Configure the rate limiter with appropriate settings.
4. Apply the rate limiter to the Express application.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
